### PR TITLE
Content design ME summary amends V11

### DIFF
--- a/app/views/V11/me-mccd-summary.html
+++ b/app/views/V11/me-mccd-summary.html
@@ -10,7 +10,7 @@ GOV.UK page template - {{ serviceName }} - GOV.UK Prototype Kit
     <div class="govuk-grid-column-full">
 
         <h1 class="govuk-heading-l govuk-!-margin-bottom-1">MCCD summary</h1>
-            <p class="govuk-!-margin-bottom-7">MCCD reference number: #327463</p>
+            <p class="govuk-!-margin-bottom-7">MCCD reference number: 327463</p>
 
         <div class="govuk-summary-card">
 
@@ -164,7 +164,7 @@ GOV.UK page template - {{ serviceName }} - GOV.UK Prototype Kit
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
-                            Implants removed?
+                            Implants removed
                         </dt>
                         <dd class="govuk-summary-list__value">
                             {{ data['implant-removed']}}
@@ -244,7 +244,7 @@ GOV.UK page template - {{ serviceName }} - GOV.UK Prototype Kit
 
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
-                            Death affected by employment?
+                            Death affected by employment
                         </dt>
                         <dd class="govuk-summary-list__value">
                             {{ data['caused-by-employment']}}
@@ -263,7 +263,7 @@ GOV.UK page template - {{ serviceName }} - GOV.UK Prototype Kit
 
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
-                            Death affected by pregnancy?
+                            Death affected by pregnancy
                         </dt>
                         <dd class="govuk-summary-list__value">
                             {{ data['pregnancy-contributed'] or 'Not applicable' }}
@@ -374,13 +374,13 @@ GOV.UK page template - {{ serviceName }} - GOV.UK Prototype Kit
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="decision-approve" name="me-decision" type="radio" value="approve">
                             <label class="govuk-label govuk-radios__label" for="decision-approve">
-                                Approve certificate
+                                Approve and sign off the MCCD
                             </label>
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="decision-reject" name="me-decision" type="radio" value="reject" data-aria-controls="conditional-contact">
                             <label class="govuk-label govuk-radios__label" for="decision-reject">
-                                Reject certificate
+                                Reject the MCCD
                             </label>
                         </div>
                         <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
@@ -390,8 +390,8 @@ GOV.UK page template - {{ serviceName }} - GOV.UK Prototype Kit
                                     Provide reason for rejection
                                 </label>
                                 <div id="reject-reason-hint" class="govuk-hint">
-                                    Include any amends required for the attending practitioner to review as well as
-                                    further discussions to be had if needed
+                                    Include any amendments that the attending practitioner must do or
+                                    any further discussions that must take place before the MCCD can be signed off.
                                 </div>
                                 <textarea class="govuk-textarea" id="reject-reason" name="decision-reject" rows="5"
                                     aria-describedby="reject-reason-hint"></textarea>


### PR DESCRIPTION
Amend H1 to: Medical certificate of cause of death (MCCD) summary.

Remove the ‘#' underneath the H1 so it’s just MCCD reference number: 327463

Remove the '?'s from:Implants removedDeath affected by employmentDeath affected by pregnancy

Under the Medical examiner decision amend Approve certificateReject certificateto:Approve and sign off the MCCDReject the MCCD

Under Reject certificate amend the paragraph to:Include any amendments that the attending practitioner must do or any further discussions that must take place before the MCCD can be signed off.